### PR TITLE
Bring the web site at least marginally up to date

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,25 +4,27 @@
 <h1>Ann Arbor Civic Technology Meetup (a2civictech)</h1>
 <h2>Ann Arbor Civic Technology Meetup (a2civictech)</h2>
 <p>
-  The Ann Arbor Civic Technology Meetup (a2civictech) meets on the 4th Monday of most fall and winter months
-  at a variety of locations
-  in the Ann Arbor area.
-  We are taking a break for summer 2016.
+  The Ann Arbor Civic Technology Meetup (a2civictech) 
+  meets at Ann Arbor City Hall 
+  during City of Ann Arbor public meetings
+  and at other locations throughout Washtenaw County
+  at other public meetings.
 </p>
 <p>
   To RSVP for a future meeting, see our <a href="http://meetup.com/a2civictech">Meetup</a> site.
   The next meeting is not yet planned; the location is to be determined.
   Join the Meetup group to get meeting locations and future dates for events.
+  Ann Arbor City Council meetings are generally Mondays at 7:00 p.m., with exceptions for holidays.
 </p>
 <p>
-  The group meets to discuss technology and the city. Attendees include 
-  programmers, project managers, municipal and county IT managers,
+  The group meets to discuss technology and the city. 
+  Attendees include programmers, project managers, municipal and county IT managers,
   civic organizers, local politicians, 
   and the occasional curious soul who finds the group on Meetup and decides to join in.
 </p>
 <p>
-  We use a <a href="https://github.com/a2civictech/a2civictech/issues">Github issues</a>
-  tracker to identify open civic issues and to track projects for the group.
+  We use a <a href="https://github.com/a2civictech/a2civictech/issues">Github issues</a> tracker
+  to identify open civic issues and to track projects for the group.
   To participate and contribute, you'll want a free <a href="https://github.com/join">Github account</a>.
 </p>
 <p>
@@ -34,7 +36,7 @@
     part of the worldwide <a href="http://localwiki.org">Localwiki</a> project.
   </ul>
   <ul>
-    <a href="http://a2docs.aadl.org">The Ann Arbor Area Government Document Repository</a>,
+    <a href="http://a2docs.org">The Ann Arbor Area Government Document Repository</a>,
     an independent collection of public records related to local municipal governance
     hosted at the <a href="http://aadl.org">Ann Arbor District Library</a>.
   </ul>
@@ -47,5 +49,6 @@
 <p>
   Questions? Send them to Edward Vielmetti, edward.vielmetti@gmail.com . 
 </p>
+  <h5>Updated 2019-10-13</h5>
 </body>
 </html>


### PR DESCRIPTION
Handle a few changes, bring it into the present day, and 
note that the Meetup group is the true source of meeting
notices for now.